### PR TITLE
Ignore muted alerts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,4 +45,11 @@ resource "datadog_monitor" "generic_datadog_monitor" {
   }
 
   locked = var.locked
+
+  # We don't want to manage muted alerts in Terraform.
+  lifecycle {
+    ignore_changes = [
+      silenced
+    ]
+  }
 }


### PR DESCRIPTION
As discussed with @rhynix 

Ignoring muted alerts in terraform. This is more of a UI managed thing and rather temporary
