### PR TITLE
Add variable for timeout of triggered monitor

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "datadog_monitor" "generic_datadog_monitor" {
 
   no_data_timeframe = var.no_data_timeframe
   notify_no_data    = var.notify_no_data
-  timeout_h         = var.timeout_h
+  timeout_h         = var.auto_resolve_time_h
 
   require_full_window = var.require_full_window
 

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ resource "datadog_monitor" "generic_datadog_monitor" {
 
   no_data_timeframe = var.no_data_timeframe
   notify_no_data    = var.notify_no_data
+  timeout_h         = var.timeout_h
 
   require_full_window = var.require_full_window
 

--- a/variables.tf
+++ b/variables.tf
@@ -143,7 +143,7 @@ variable "priority" {
   default = null
 }
 
-variable "timeout_h" {
+variable "auto_resolve_time_h" {
   description = "Time of hours after which a triggered monitor that receives no data is automatically resolved."
 
   type    = number

--- a/variables.tf
+++ b/variables.tf
@@ -142,3 +142,10 @@ variable "priority" {
   type    = number
   default = null
 }
+
+variable "timeout_h" {
+  description = "Time of hours after which a triggered monitor that receives no data is automatically resolved."
+
+  type    = number
+  default = null
+}


### PR DESCRIPTION
This is useful when certain metrics are only reported for limited time and them disappearing meaning that the triggered state can be safely resolved.

For instance, when you track the runtime of a background job and alert if it has been running for a long time, the metrics no longer being received probably means that the job has finished. In this you also want the alert to be resolved.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
