### PR TITLE
Remove deprecated locked variable and add restricted_roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Pre-commit:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.12.0 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.19.1 |
 
 ## Modules
 
@@ -49,7 +49,6 @@ No modules.
 | <a name="input_docs"></a> [docs](#input\_docs) | Field in the alert message that can be used to document why the alert was sent or what to do. It's best to include links to authoritative resources about what's being monitored. Try to capture why and what the engineer should do with this message | `string` | `""` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | If set to false the monitor resource will not be created | `bool` | `true` | no |
 | <a name="input_env"></a> [env](#input\_env) | This refers to the environment or which stage of deployment this monitor is checking. Good values are prd, acc, tst, dev... | `string` | n/a | yes |
-| <a name="input_locked"></a> [locked](#input\_locked) | Makes sure only the creator or admin can modify the monitor | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name that the monitor should get. Will be automatically prefixed with the Service name. Also name\_suffix and name\_prefix have an effect on the eventual name. It's best set this property to a value that best describes the concern you're trying to cover with the monitor. Eg. Connection Available | `string` | n/a | yes |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Can be used to prefix to the Monitor name | `string` | `""` | no |
 | <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | Can be used to suffix to the Monitor name | `string` | `""` | no |
@@ -64,6 +63,7 @@ No modules.
 | <a name="input_query"></a> [query](#input\_query) | Query that's based on a metric to be used to raise an alert | `string` | n/a | yes |
 | <a name="input_recovery_message"></a> [recovery\_message](#input\_recovery\_message) | Recovery message to be sent when the alert threshold is no longer hit | `string` | `""` | no |
 | <a name="input_require_full_window"></a> [require\_full\_window](#input\_require\_full\_window) | n/a | `bool` | `true` | no |
+| <a name="input_restricted_roles"></a> [restricted\_roles](#input\_restricted\_roles) | A list of unique role identifiers to define which roles are allowed to edit the monitor. | `list(string)` | `[]` | no |
 | <a name="input_service"></a> [service](#input\_service) | Service name of what you're monitoring. This also sets the service:<service> tag on the monitor | `string` | n/a | yes |
 | <a name="input_service_display_name"></a> [service\_display\_name](#input\_service\_display\_name) | n/a | `string` | `null` | no |
 | <a name="input_type"></a> [type](#input\_type) | n/a | `string` | `"metric alert"` | no |

--- a/main.tf
+++ b/main.tf
@@ -88,5 +88,5 @@ resource "datadog_monitor" "generic_datadog_monitor" {
     trigger_window  = var.anomaly_trigger_window
   }
 
-  locked = var.locked
+  restricted_roles = var.restricted_roles
 }

--- a/variables.tf
+++ b/variables.tf
@@ -151,10 +151,10 @@ variable "notify_no_data" {
   default     = false
 }
 
-variable "locked" {
-  description = "Makes sure only the creator or admin can modify the monitor"
-  type        = bool
-  default     = true
+variable "restricted_roles" {
+  description = "A list of unique role identifiers to define which roles are allowed to edit the monitor."
+  type        = list(string)
+  default     = []
 }
 
 variable "name_prefix" {


### PR DESCRIPTION
The locked argument is deprecated[ since the 3.11 provider version.](https://github.com/DataDog/terraform-provider-datadog/blob/master/CHANGELOG.md#notes-6)
This generates lots of deprecation warnings in our system and I'd like to clean it.
Example of the warning:
![Screenshot 2022-12-30 at 18 41 31](https://user-images.githubusercontent.com/2135758/210098277-4926700b-c7e8-43cd-b62c-1463ed11f69e.png)
